### PR TITLE
Remove # noqa and torques_sat is now a vector

### DIFF
--- a/solo_pybullet/PD.py
+++ b/solo_pybullet/PD.py
@@ -4,12 +4,12 @@
 import numpy as np
 
 
-def PD(qa_ref, qa_dot_ref, qa, qa_dot, dt, Kp=1, Kd=1, torque_sat=100, torques_ref=np.zeros((8, 1))):
+def PD(qa_ref, qa_dot_ref, qa, qa_dot, dt, Kp=1, Kd=1, torques_sat=5*np.ones((8, 1)), torques_ref=np.zeros((8, 1))):
 
     # Output torques
     torques = Kp * (qa_ref - qa) + Kd * (qa_dot_ref - qa_dot) + torques_ref
 
     # Saturation to limit the maximal value that torques can have
-    torques = np.maximum(np.minimum(torques, torque_sat * np.ones((8, 1))), -torque_sat * np.ones((8, 1)))
+    torques = np.maximum(np.minimum(torques, torques_sat), -torques_sat)
 
     return torques

--- a/solo_pybullet/__main__.py
+++ b/solo_pybullet/__main__.py
@@ -20,7 +20,7 @@ dt = 0.001  # time step of the simulation
 # If True then we will sleep in the main loop to have a 1:1 ratio of (elapsed real time / elapsed time in the
 # simulation))
 realTimeSimulation = True
-enableGUI = False  # enable PyBullet GUI or not
+enableGUI = True  # enable PyBullet GUI or not
 robotId, solo, revoluteJointIndices = configure_simulation(dt, enableGUI)
 
 ###############

--- a/solo_pybullet/controller.py
+++ b/solo_pybullet/controller.py
@@ -34,11 +34,11 @@ def c(q, qdot, dt):
     # Parameters for the PD controller
     Kp = 8.
     Kd = 0.06
-    torque_sat = 3  # torque saturation in N.m
+    torques_sat = 3 * np.ones((8, 1))  # torque saturation in N.m
     torques_ref = np.zeros((8, 1))  # feedforward torques
 
     # Call the PD controller
-    torques = PD(qa_ref, qa_dot_ref, qa, qa_dot, dt, Kp, Kd, torque_sat, torques_ref)
+    torques = PD(qa_ref, qa_dot_ref, qa, qa_dot, dt, Kp, Kd, torques_sat, torques_ref)
 
     # torques must be a numpy array of shape (8, 1) containing the torques applied to the 8 motors
     return torques
@@ -174,11 +174,11 @@ def c_walking(q, qdot, dt, solo, t_simu):
     # Parameters for the PD controller
     Kp = 8.
     Kd = 0.2
-    torque_sat = 3  # torque saturation in N.m
+    torques_sat = 3 * np.ones((8, 1))  # torque saturation in N.m
     torques_ref = np.zeros((8, 1))  # feedforward torques
 
     # Call the PD controller
-    torques = PD(qa_ref, qa_dot_ref, qa, qa_dot, dt, Kp, Kd, torque_sat, torques_ref)
+    torques = PD(qa_ref, qa_dot_ref, qa, qa_dot, dt, Kp, Kd, torques_sat, torques_ref)
 
     # torques must be a numpy array of shape (8, 1) containing the torques applied to the 8 motors
     return torques

--- a/solo_pybullet/controller.py
+++ b/solo_pybullet/controller.py
@@ -14,12 +14,12 @@ from .PD import PD
 
 def c(q, qdot, dt):
     # unactuated, [x, y, z] position of the base + [x, y, z, w] orientation of the base (stored as a quaternion)
-    qu = q[:7]  # noqa
+    # qu = q[:7]
     # actuated, [q1, q2, ..., q8] angular position of the 8 motors
     qa = q[7:]
     # [v_x, v_y, v_z] linear velocity of the base and [w_x, w_y, w_z] angular velocity of the base along x, y, z axes
     # of the world
-    qu_dot = qdot[:6]  # noqa
+    # qu_dot = qdot[:6]
     qa_dot = qdot[6:]  # angular velocity of the 8 motors
 
     qa_ref = np.zeros((8, 1))  # target angular positions for the motors
@@ -55,11 +55,11 @@ flag_q_ref = True
 
 def c_walking(q, qdot, dt, solo, t_simu):
     # unactuated, [x, y, z] position of the base + [x, y, z, w] orientation of the base (stored as a quaternion)
-    qu = q[:7]  # noqa
+    # qu = q[:7]
     qa = q[7:]  # actuated, [q1, q2, ..., q8] angular position of the 8 motors
     # [v_x, v_y, v_z] linear velocity of the base and [w_x, w_y, w_z] angular velocity of the base along x, y, z axes
     # of the world
-    qu_dot = qdot[:6]  # noqa
+    # qu_dot = qdot[:6]
     qa_dot = qdot[6:]  # angular velocity of the 8 motors
 
     qa_ref = np.zeros((8, 1))  # target angular positions for the motors


### PR DESCRIPTION
# noqa is used by the linter to avoid a warning with unused variables.
Instead of having `unused_variable = something # noqa` the line is now commented `# unused_variable = something`.

The scalar `torque_sat` is now replaced with a vector `torques_sat`

PyBullet GUI is now turned on by default.